### PR TITLE
Update grunt-contrib-jasmine to version 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "grunt test"
   },
   "dependencies" : {
-    "grunt-contrib-jasmine": "~0.5.2"
+    "grunt-contrib-jasmine": "~0.9.1"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",


### PR DESCRIPTION
Since grunt-contrib-jasmine version 0.6 jasmine 2.0 is available.